### PR TITLE
fix for hanging indents

### DIFF
--- a/Academia.css
+++ b/Academia.css
@@ -261,7 +261,7 @@ blockquote p {
 }
 
 div.refs>p,div#refs>div[id^="ref"]>p {
-    padding-left: 4em;
+    padding-left: 2em;
     text-indent: -2em;
 }
 

--- a/Academia.css
+++ b/Academia.css
@@ -260,8 +260,8 @@ blockquote p {
     padding-left: 0.35ex;
 }
 
-div.refs>p,div#refs>p {
-    padding-left: 2em;
+div.refs>p,div#refs>div[id^="ref"]>p {
+    padding-left: 4em;
     text-indent: -2em;
 }
 


### PR DESCRIPTION
Hanging indents didn't work for me initially. Each reference "p" got its own id, so I added a "Substring matching attribute selector" and that seems to do the trick.